### PR TITLE
Default to live mode for empty settings.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -104,7 +104,7 @@ export default class ViewModeByFrontmatterPlugin extends Plugin {
         ? this.app.vault.config.defaultViewMode
         : "source";
 
-      const defaultEditingModeIsLivePreview = this.app.vault.config.livePreview;
+      const defaultEditingModeIsLivePreview = this.app.vault.config.livePreview === undefined ? true : this.app.vault.config.livePreview;
 
       if (!this.settings.ignoreForceViewAll) {
         let state = leaf.getViewState();


### PR DESCRIPTION
May fix Broken Preview Mode? #29
It appears that it is possible for the config.livePreview to be undefined for new vaults. On my machine (v1.3.4 appimage for linux) , the contents of app.json on a new vault is an empty object. Therefore, by default config.livePreview is undefined, and only is set if you alter the default settings. This change correctly sets the livePreview mode to true if it is undefined in the config.